### PR TITLE
Use Consolas and Liberation Mono for monospace on Windows and Linux

### DIFF
--- a/src/Components/App.css
+++ b/src/Components/App.css
@@ -9,7 +9,7 @@
 
   --font-face: "Source Sans Pro", Arial, Helvetica, sans-serif;
   --font-size: 14px;
-  --font-mono-face: Menlo, Monaco, "Courier New", monospace;
+  --font-mono-face: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-mono-size: 12px;
 
   --panel-roundness: 5px;

--- a/src/Components/Terminal.css
+++ b/src/Components/Terminal.css
@@ -9,7 +9,7 @@ This very-specific selector is needed to override some settings from App.css.
   --color: #333;
   --background: white;
   --size: 1;
-  --font: Menlo, Monaco, "Courier New", monospace;
+  --font: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .xterm {

--- a/src/Components/Terminal.tsx
+++ b/src/Components/Terminal.tsx
@@ -75,7 +75,7 @@ export function Terminal({
         selectionBackground: "#9999CC",
       },
       // TODO: Set fonts from CSS?
-      fontFamily: "Menlo, Monaco, Courier New, Monospace",
+      fontFamily: "Menlo, Monaco, Consolas, Liberation Mono, Courier New, Monospace",
       fontSize: 12,
     });
     const fitAddon = new FitAddon();


### PR DESCRIPTION
Also, I noticed that Source Sans Pro is being used but it doesn't look like the Google font is being loaded, so it'll look like Arial/Helvetica unless you happen to have the font installed locally.