### PR TITLE
Fix reactive function name

### DIFF
--- a/examples/reactive_value/app.py
+++ b/examples/reactive_value/app.py
@@ -30,9 +30,9 @@ def server(input, output, session):
     # A reactive.Value with an array tracking timestamps of all button presses.
     all_times = reactive.Value([datetime.now().timestamp()])
 
-    # This Effect is triggered by pressing the button. It makes a copy of last_vals(),
+    # This Effect is triggered by pressing the button. It makes a copy of all_times(),
     # because we don't want to modify the original, then appends the new timestamp,
-    # then sets last_vals() to the new, longer array.
+    # then sets all_times() to the new, longer array.
     @reactive.Effect
     @reactive.event(input.btn)
     def _():


### PR DESCRIPTION
A minor update with the replacement of the wrong reactive function name with a proper one in the comments.