### PR TITLE
Update esbuild to v0.17 and rewrite `build.ts` for the new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "balloon-css": "^1.2.0",
     "codemirror": "^6.0.1",
     "dompurify": "^3.0.0",
-    "esbuild": "^0.16.17",
+    "esbuild": "^0.17.19",
     "eslint": "^8.34.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,3 @@
-// Live-reload script taken from https://github.com/evanw/esbuild/issues/802#issuecomment-819578182
 import packageJson from "../package.json";
 import buildExamples from "./build_examples_json";
 import { spawn } from "child_process";
@@ -9,6 +8,7 @@ import process from "process";
 
 const EXAMPLES_SOURCE_DIR = "./examples";
 const BUILD_DIR = "./build";
+const SITE_DIR = "./site";
 
 const SHINYLIVE_VERSION = packageJson.version;
 const currentYear = new Date().getFullYear();
@@ -45,235 +45,225 @@ if (process.argv.some((x) => x === "--test-server")) {
   openBrowser = false;
 }
 
-const onRebuild = (
-  error: esbuild.BuildFailure | null,
-  result: esbuild.BuildResult | null
-): void => {
-  clients.forEach((res) => res.write("data: update\n\n"));
-  clients.length = 0;
-
-  console.log(
-    `[${new Date().toISOString()}]` +
-      (error ? error : " Rebuilding JS files...")
-  );
+const buildmap = {
+  'app':
+    esbuild.context({
+      bundle: true,
+      entryPoints: {
+        shinylive: "src/Components/App.tsx",
+        Editor: "src/Components/Editor.tsx",
+      },
+      outdir: `${SITE_DIR}/shinylive/`,
+      // All of these are dynamic imports in pyodide.mjs (which we copied to
+      // src/pyodide/pyodide.js). It will never actually do these imports, so
+      // we'll mark them as external so esbuild doesn't try to bundle them.
+      external: [
+        "node-fetch",
+        "path",
+        "fs",
+        "vm",
+        "crypto",
+        "child_process",
+        "url",
+        "ws",
+      ],
+      format: "esm",
+      target: "es2020",
+      splitting: true,
+      // It would be more organized to put the chunks in "chunks/[name]", but this
+      // causes problems when ../pyodide/pyodide.js loads "pyodide_py.tar" -- it
+      // looks in /shinylive/chunks/pyodide/pyodide_py.tar, which doesn't exist.
+      // This probably has something to do with how pyodide.js specifies the path.
+      chunkNames: "[name]-[hash]",
+      minify: minify,
+      banner: banner,
+      metafile: metafile,
+      define: {
+        "process.env.NODE_ENV": reactProductionMode
+          ? '"production"'
+          : '"development"',
+      },
+      loader: {
+        ".svg": "dataurl",
+      },
+      plugins: [
+        {
+          // This removes previously-built chunk-[hash].js files so that they
+          // don't clutter up the build directory.
+          name: "chunk-cleaner",
+          setup(build) {
+            build.onStart(async () => {
+              fs.readdirSync(`${BUILD_DIR}/shinylive/`)
+                .filter((file) => file.startsWith("chunk-"))
+                .forEach((file) => {
+                  fs.unlinkSync(`${BUILD_DIR}/shinylive/${file}`);
+                });
+            });
+          },
+        },
+        {
+          name: "example-builder",
+          setup(build) {
+            build.onStart(() => {
+              // On every rebuild make sure the examples are up to date.
+              // One issue is this won't force esbuild to watch for the changes
+              // of the example files themselves so live-reloading won't work
+              buildExamples(EXAMPLES_SOURCE_DIR, BUILD_DIR);
+            });
+          },
+        },
+      ],
+    }),
+  'worker':
+    esbuild.context({
+      bundle: true,
+      entryPoints: [
+        "src/pyodide-worker.ts",
+        "src/load-shinylive-sw.ts",
+        "src/run-python-blocks.ts",
+      ],
+      outdir: `${BUILD_DIR}/shinylive`,
+      // See note in esbuild.build() call above about why these are external.
+      external: [
+        "node-fetch",
+        "path",
+        "fs",
+        "vm",
+        "crypto",
+        "child_process",
+        "url",
+        // shinylive.js is used in run-python-blocks.ts, but we don't want to
+        // bundle it.
+        "./shinylive.js",
+      ],
+      format: "esm",
+      target: "es2020",
+      minify: minify,
+      banner: banner,
+    }),
+  'codeblock-to-json':
+    esbuild.context({
+      bundle: true,
+      entryPoints: ["src/scripts/codeblock-to-json.ts"],
+      outdir: `${BUILD_DIR}/scripts`,
+      format: "esm",
+      target: "es2022",
+      minify: minify,
+      banner: banner,
+    }),
+  // Compile src/shinylive-inject-socket.ts to
+  // src/assets/shinylive-inject-socket.txt. That file is in turn ingested into
+  // shinylive-sw.js.
+  'shinylive-inject-socket':
+    esbuild.context({
+      bundle: true,
+      entryPoints: ["src/shinylive-inject-socket.ts"],
+      outfile: "src/assets/shinylive-inject-socket.txt",
+      format: "esm",
+      target: "es2020",
+      // Don't minify, because the space savings are minimal, and the it will lead
+      // to spurious diffs when building for dev vs. prod.
+      minify: false,
+    }),
+  'shinylive-sw':
+    esbuild.context({
+      bundle: true,
+      entryPoints: ["src/shinylive-sw.ts"],
+      outdir: `${BUILD_DIR}`,
+      format: "esm",
+      target: "es2020",
+      minify: minify,
+      banner: banner,
+    })
 };
 
-let watchProp = {};
-if (watch) {
-  watchProp = { watch: { onRebuild } };
+Object.values(buildmap).forEach((build) =>
+  build
+    .then((context) => {
+      context.rebuild()
+      return context;
+    })
+    .then((context) => {
+      if (watch) context.watch();
+    })
+    .catch(() => process.exit(1))
+);
+
+if (metafile) {
+  buildmap['app']
+    .then((context) => context.rebuild())
+    .then((result) => {
+      fs.writeFileSync("esbuild-meta.json", JSON.stringify(result.metafile));
+    })
+    .catch(() => process.exit(1))
 }
 
-esbuild
-  .build({
-    bundle: true,
-    entryPoints: {
-      shinylive: "src/Components/App.tsx",
-      Editor: "src/Components/Editor.tsx",
-    },
-    outdir: `${BUILD_DIR}/shinylive/`,
-    // All of these are dynamic imports in pyodide.mjs (which we copied to
-    // src/pyodide/pyodide.js). It will never actually do these imports, so
-    // we'll mark them as external so esbuild doesn't try to bundle them.
-    external: [
-      "node-fetch",
-      "path",
-      "fs",
-      "vm",
-      "crypto",
-      "child_process",
-      "url",
-      "ws",
-    ],
-    format: "esm",
-    target: "es2020",
-    splitting: true,
-    // It would be more organized to put the chunks in "chunks/[name]", but this
-    // causes problems when ../pyodide/pyodide.js loads "pyodide_py.tar" -- it
-    // looks in /shinylive/chunks/pyodide/pyodide_py.tar, which doesn't exist.
-    // This probably has something to do with how pyodide.js specifies the path.
-    chunkNames: "[name]-[hash]",
-    minify: minify,
-    banner: banner,
-    metafile: metafile,
-    define: {
-      "process.env.NODE_ENV": reactProductionMode
-        ? '"production"'
-        : '"development"',
-    },
-    ...watchProp,
-    loader: {
-      ".svg": "dataurl",
-    },
-    plugins: [
-      {
-        // This removes previously-built chunk-[hash].js files so that they
-        // don't clutter up the build directory.
-        name: "chunk-cleaner",
-        setup(build) {
-          build.onStart(async () => {
-            fs.readdirSync(`${BUILD_DIR}/shinylive/`)
-              .filter((file) => file.startsWith("chunk-"))
-              .forEach((file) => {
-                fs.unlinkSync(`${BUILD_DIR}/shinylive/${file}`);
-              });
-          });
-        },
-      },
-      {
-        name: "example-builder",
-        setup(build) {
-          build.onStart(() => {
-            // On every rebuild make sure the examples are up to date.
-            // One issue is this won't force esbuild to watch for the changes
-            // of the example files themselves so live-reloading won't work
-            buildExamples(EXAMPLES_SOURCE_DIR, BUILD_DIR);
-          });
-        },
-      },
-    ],
-  })
-  .then((result) => {
-    if (metafile) {
-      fs.writeFileSync("esbuild-meta.json", JSON.stringify(result.metafile));
-    }
-  })
-  .catch(() => process.exit(1));
-
-esbuild
-  .build({
-    bundle: true,
-    entryPoints: [
-      "src/pyodide-worker.ts",
-      "src/load-shinylive-sw.ts",
-      "src/run-python-blocks.ts",
-    ],
-    outdir: `${BUILD_DIR}/shinylive`,
-    // See note in esbuild.build() call above about why these are external.
-    external: [
-      "node-fetch",
-      "path",
-      "fs",
-      "vm",
-      "crypto",
-      "child_process",
-      "url",
-      // shinylive.js is used in run-python-blocks.ts, but we don't want to
-      // bundle it.
-      "./shinylive.js",
-    ],
-    format: "esm",
-    target: "es2020",
-    minify: minify,
-    banner: banner,
-    ...watchProp,
-  })
-  .catch(() => process.exit(1));
-
-esbuild
-  .build({
-    bundle: true,
-    entryPoints: ["src/scripts/codeblock-to-json.ts"],
-    outdir: `${BUILD_DIR}/scripts`,
-    format: "esm",
-    target: "es2022",
-    minify: minify,
-    banner: banner,
-    ...watchProp,
-  })
-  .catch(() => process.exit(1));
-
-// Compile src/shinylive-inject-socket.ts to
-// src/assets/shinylive-inject-socket.txt. That file is in turn ingested into
-// shinylive-sw.js.
-esbuild
-  .build({
-    bundle: true,
-    entryPoints: ["src/shinylive-inject-socket.ts"],
-    outfile: "src/assets/shinylive-inject-socket.txt",
-    format: "esm",
-    target: "es2020",
-    // Don't minify, because the space savings are minimal, and the it will lead
-    // to spurious diffs when building for dev vs. prod.
-    minify: false,
-    ...watchProp,
-  })
-  .catch(() => process.exit(1));
-
-esbuild
-  .build({
-    bundle: true,
-    entryPoints: ["src/shinylive-sw.ts"],
-    outdir: `${BUILD_DIR}`,
-    format: "esm",
-    target: "es2020",
-    minify: minify,
-    banner: banner,
-    ...watchProp,
-  })
-  .catch(() => process.exit(1));
-
 if (serve) {
-  esbuild.serve({ servedir: "site/", port: 3001 }, {}).then(() => {
-    http
-      .createServer((req, res) => {
-        const { url, method, headers } = req;
+  buildmap['app']
+    .then((context) => {
+      context.serve({ servedir: SITE_DIR, port: 3001 }).then(() => {
+        http
+          .createServer((req, res) => {
+            const { url, method, headers } = req;
+            req.pipe(
+              http.request(
+                { hostname: "0.0.0.0", port: 3001, path: url, method, headers },
+                (proxyRes) => {
+                  if (url === "/shinylive/shinylive.js") {
+                    // JS code for does auto-reloading. We'll inject it into
+                    // shinylive.js as it's sent.
+                    const jsReloadCode = `(() => {
+                      if (window.location.host.includes("localhost")) {
+                        console.log('%c~~~~~ Live Reload Enabled ~~~~~~', 'font-weight:bold;font-size:20px;color:white;display:block;background-color:green;padding:4px;border-radius:5px;');
+                        new EventSource('/esbuild').addEventListener('change', () => location.reload())
+                      }
+                    })();`;
 
-        if (req.url === "/esbuild")
-          return clients.push(
-            res.writeHead(200, {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-            })
-          );
+                    const newHeaders = {
+                      ...proxyRes.headers,
+                      "content-length":
+                        parseInt(proxyRes.headers["content-length"]!, 10) +
+                        jsReloadCode.length,
+                    };
 
-        req.pipe(
-          http.request(
-            { hostname: "0.0.0.0", port: 3001, path: url, method, headers },
-            (proxyRes) => {
-              if (url === "/shinylive/shinylive.js") {
-                // JS code for does auto-reloading. We'll inject it into
-                // shinylive.js as it's sent.
-                const jsReloadCode = `(() => {
-                  if (window.location.host.includes("localhost")) {
-                    console.log('%c~~~~~ Live Reload Enabled ~~~~~~', 'font-weight:bold;font-size:20px;color:white;display:block;background-color:green;padding:4px;border-radius:5px;');
-                    new EventSource("/esbuild").onmessage = () => location.reload();
+                    res.writeHead(proxyRes.statusCode!, newHeaders);
+                    res.write(jsReloadCode);
+                  } else {
+                    const client = res.writeHead(proxyRes.statusCode!, proxyRes.headers);
+                    if (req.url === "/esbuild")
+                      clients.push(client);
                   }
-                })();`;
+                  proxyRes.pipe(res, { end: true });
+                }
+              ),
+              { end: true }
+            );
+          })
+          .listen(3000);
 
-                const newHeaders = {
-                  ...proxyRes.headers,
-                  "content-length":
-                    parseInt(proxyRes.headers["content-length"]!, 10) +
-                    jsReloadCode.length,
-                };
-
-                res.writeHead(proxyRes.statusCode!, newHeaders);
-                res.write(jsReloadCode);
-              } else {
-                res.writeHead(proxyRes.statusCode!, proxyRes.headers);
-              }
-              proxyRes.pipe(res, { end: true });
+        if (openBrowser) {
+          setTimeout(() => {
+            const op = {
+              darwin: ["open"],
+              linux: ["xdg-open"],
+              win32: ["cmd", "/c", "start"],
+            };
+            if (clients.length === 0) {
+              // @ts-expect-error: `process.platform` could have many other values,
+              //like aix, android, haiku, openbsd, freebsd, etc.
+              spawn(op[process.platform][0], [`http://localhost:3000/examples`]);
             }
-          ),
-          { end: true }
-        );
-      })
-      .listen(3000);
-
-    if (openBrowser) {
-      setTimeout(() => {
-        const op = {
-          darwin: ["open"],
-          linux: ["xdg-open"],
-          win32: ["cmd", "/c", "start"],
-        };
-        if (clients.length === 0) {
-          // @ts-expect-error: `process.platform` could have many other values,
-          //like aix, android, haiku, openbsd, freebsd, etc.
-          spawn(op[process.platform][0], [`http://localhost:3000/examples`]);
+          }, 1000); //open the default browser only if it is not opened yet
         }
-      }, 1000); //open the default browser only if it is not opened yet
-    }
+      });
+    })
+    .catch(() => process.exit(1));
+}
+
+if (!watch && !serve) {
+  Object.values(buildmap).forEach(build => {
+    build.then((context) => {
+      context.dispose();
+    });
   });
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -45,6 +45,15 @@ if (process.argv.some((x) => x === "--test-server")) {
   openBrowser = false;
 }
 
+const rebuildLoggerPlugin = {
+  name: "rebuild-logger",
+  setup(build: esbuild.PluginBuild) {
+    build.onStart(() => {
+      console.log(`[${new Date().toISOString()}] Rebuilding JS files...`);
+    });
+  }
+}
+
 const buildmap = {
   'app':
     esbuild.context({
@@ -87,6 +96,7 @@ const buildmap = {
         ".svg": "dataurl",
       },
       plugins: [
+        rebuildLoggerPlugin,
         {
           // This removes previously-built chunk-[hash].js files so that they
           // don't clutter up the build directory.
@@ -140,6 +150,7 @@ const buildmap = {
       target: "es2020",
       minify: minify,
       banner: banner,
+      plugins: [ rebuildLoggerPlugin ],
     }),
   'codeblock-to-json':
     esbuild.context({
@@ -150,6 +161,7 @@ const buildmap = {
       target: "es2022",
       minify: minify,
       banner: banner,
+      plugins: [ rebuildLoggerPlugin ],
     }),
   // Compile src/shinylive-inject-socket.ts to
   // src/assets/shinylive-inject-socket.txt. That file is in turn ingested into
@@ -164,6 +176,7 @@ const buildmap = {
       // Don't minify, because the space savings are minimal, and the it will lead
       // to spurious diffs when building for dev vs. prod.
       minify: false,
+      plugins: [ rebuildLoggerPlugin ],
     }),
   'shinylive-sw':
     esbuild.context({
@@ -174,6 +187,7 @@ const buildmap = {
       target: "es2020",
       minify: minify,
       banner: banner,
+      plugins: [ rebuildLoggerPlugin ],
     })
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,13 +624,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm64@npm:0.16.17"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm64@npm:0.17.10":
   version: 0.17.10
   resolution: "@esbuild/android-arm64@npm:0.17.10"
@@ -638,10 +631,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm@npm:0.16.17"
-  conditions: os=android & cpu=arm
+"@esbuild/android-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm64@npm:0.17.19"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -652,10 +645,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-x64@npm:0.16.17"
-  conditions: os=android & cpu=x64
+"@esbuild/android-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-arm@npm:0.17.19"
+  conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
@@ -666,10 +659,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-arm64@npm:0.16.17"
-  conditions: os=darwin & cpu=arm64
+"@esbuild/android-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/android-x64@npm:0.17.19"
+  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -680,10 +673,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-x64@npm:0.16.17"
-  conditions: os=darwin & cpu=x64
+"@esbuild/darwin-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-arm64@npm:0.17.19"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -694,10 +687,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-arm64@npm:0.16.17"
-  conditions: os=freebsd & cpu=arm64
+"@esbuild/darwin-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/darwin-x64@npm:0.17.19"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -708,10 +701,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-x64@npm:0.16.17"
-  conditions: os=freebsd & cpu=x64
+"@esbuild/freebsd-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-arm64@npm:0.17.19"
+  conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -722,10 +715,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm64@npm:0.16.17"
-  conditions: os=linux & cpu=arm64
+"@esbuild/freebsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/freebsd-x64@npm:0.17.19"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -736,10 +729,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm@npm:0.16.17"
-  conditions: os=linux & cpu=arm
+"@esbuild/linux-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm64@npm:0.17.19"
+  conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -750,10 +743,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ia32@npm:0.16.17"
-  conditions: os=linux & cpu=ia32
+"@esbuild/linux-arm@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-arm@npm:0.17.19"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -764,10 +757,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-loong64@npm:0.16.17"
-  conditions: os=linux & cpu=loong64
+"@esbuild/linux-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ia32@npm:0.17.19"
+  conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
@@ -778,10 +771,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-mips64el@npm:0.16.17"
-  conditions: os=linux & cpu=mips64el
+"@esbuild/linux-loong64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-loong64@npm:0.17.19"
+  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -792,10 +785,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ppc64@npm:0.16.17"
-  conditions: os=linux & cpu=ppc64
+"@esbuild/linux-mips64el@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-mips64el@npm:0.17.19"
+  conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
@@ -806,10 +799,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-riscv64@npm:0.16.17"
-  conditions: os=linux & cpu=riscv64
+"@esbuild/linux-ppc64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-ppc64@npm:0.17.19"
+  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -820,10 +813,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-s390x@npm:0.16.17"
-  conditions: os=linux & cpu=s390x
+"@esbuild/linux-riscv64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-riscv64@npm:0.17.19"
+  conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
@@ -834,10 +827,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-x64@npm:0.16.17"
-  conditions: os=linux & cpu=x64
+"@esbuild/linux-s390x@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-s390x@npm:0.17.19"
+  conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
@@ -848,10 +841,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/netbsd-x64@npm:0.16.17"
-  conditions: os=netbsd & cpu=x64
+"@esbuild/linux-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/linux-x64@npm:0.17.19"
+  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -862,10 +855,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/openbsd-x64@npm:0.16.17"
-  conditions: os=openbsd & cpu=x64
+"@esbuild/netbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/netbsd-x64@npm:0.17.19"
+  conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -876,10 +869,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/sunos-x64@npm:0.16.17"
-  conditions: os=sunos & cpu=x64
+"@esbuild/openbsd-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/openbsd-x64@npm:0.17.19"
+  conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -890,10 +883,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-arm64@npm:0.16.17"
-  conditions: os=win32 & cpu=arm64
+"@esbuild/sunos-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/sunos-x64@npm:0.17.19"
+  conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
@@ -904,10 +897,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-ia32@npm:0.16.17"
-  conditions: os=win32 & cpu=ia32
+"@esbuild/win32-arm64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-arm64@npm:0.17.19"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -918,16 +911,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-x64@npm:0.16.17"
-  conditions: os=win32 & cpu=x64
+"@esbuild/win32-ia32@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-ia32@npm:0.17.19"
+  conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@esbuild/win32-x64@npm:0.17.10":
   version: 0.17.10
   resolution: "@esbuild/win32-x64@npm:0.17.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.17.19":
+  version: 0.17.19
+  resolution: "@esbuild/win32-x64@npm:0.17.19"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2870,32 +2870,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.16.17":
-  version: 0.16.17
-  resolution: "esbuild@npm:0.16.17"
+"esbuild@npm:^0.17.19":
+  version: 0.17.19
+  resolution: "esbuild@npm:0.17.19"
   dependencies:
-    "@esbuild/android-arm": 0.16.17
-    "@esbuild/android-arm64": 0.16.17
-    "@esbuild/android-x64": 0.16.17
-    "@esbuild/darwin-arm64": 0.16.17
-    "@esbuild/darwin-x64": 0.16.17
-    "@esbuild/freebsd-arm64": 0.16.17
-    "@esbuild/freebsd-x64": 0.16.17
-    "@esbuild/linux-arm": 0.16.17
-    "@esbuild/linux-arm64": 0.16.17
-    "@esbuild/linux-ia32": 0.16.17
-    "@esbuild/linux-loong64": 0.16.17
-    "@esbuild/linux-mips64el": 0.16.17
-    "@esbuild/linux-ppc64": 0.16.17
-    "@esbuild/linux-riscv64": 0.16.17
-    "@esbuild/linux-s390x": 0.16.17
-    "@esbuild/linux-x64": 0.16.17
-    "@esbuild/netbsd-x64": 0.16.17
-    "@esbuild/openbsd-x64": 0.16.17
-    "@esbuild/sunos-x64": 0.16.17
-    "@esbuild/win32-arm64": 0.16.17
-    "@esbuild/win32-ia32": 0.16.17
-    "@esbuild/win32-x64": 0.16.17
+    "@esbuild/android-arm": 0.17.19
+    "@esbuild/android-arm64": 0.17.19
+    "@esbuild/android-x64": 0.17.19
+    "@esbuild/darwin-arm64": 0.17.19
+    "@esbuild/darwin-x64": 0.17.19
+    "@esbuild/freebsd-arm64": 0.17.19
+    "@esbuild/freebsd-x64": 0.17.19
+    "@esbuild/linux-arm": 0.17.19
+    "@esbuild/linux-arm64": 0.17.19
+    "@esbuild/linux-ia32": 0.17.19
+    "@esbuild/linux-loong64": 0.17.19
+    "@esbuild/linux-mips64el": 0.17.19
+    "@esbuild/linux-ppc64": 0.17.19
+    "@esbuild/linux-riscv64": 0.17.19
+    "@esbuild/linux-s390x": 0.17.19
+    "@esbuild/linux-x64": 0.17.19
+    "@esbuild/netbsd-x64": 0.17.19
+    "@esbuild/openbsd-x64": 0.17.19
+    "@esbuild/sunos-x64": 0.17.19
+    "@esbuild/win32-arm64": 0.17.19
+    "@esbuild/win32-ia32": 0.17.19
+    "@esbuild/win32-x64": 0.17.19
   dependenciesMeta:
     "@esbuild/android-arm":
       optional: true
@@ -2943,7 +2943,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 4c2cc609ecfb426554bc3f75beb92d89eb2d0c515cfceebaa36c7599d7dcaab7056b70f6d6b51e72b45951ddf9021ee28e356cf205f8e42cc055d522312ea30c
+  checksum: ac11b1a5a6008e4e37ccffbd6c2c054746fc58d0ed4a2f9ee643bd030cfcea9a33a235087bc777def8420f2eaafb3486e76adb7bdb7241a9143b43a69a10afd8
   languageName: node
   linkType: hard
 
@@ -6021,7 +6021,7 @@ __metadata:
     balloon-css: ^1.2.0
     codemirror: ^6.0.1
     dompurify: ^3.0.0
-    esbuild: ^0.16.17
+    esbuild: ^0.17.19
     eslint: ^8.34.0
     eslint-plugin-react: ^7.32.2
     eslint-plugin-react-hooks: ^4.6.0


### PR DESCRIPTION
While experimenting with my shinylive/webR fork I hit [an issue with esbuild](https://github.com/evanw/esbuild/issues/2851). The issue does not affect Pyodide, but I have upgraded esbuild in my fork to avoid the bug and thought it might be a good idea to upstream the change. So, this PR upgrades esbuild from v0.16.17 to v0.17.19.

As described in the [esbuild release notes for v0.17](https://github.com/evanw/esbuild/releases/tag/v0.17.0), there is a breaking change in the `.build()` and `.serve()` API, so the shinylive `build.ts` script needed to be re-written for the upgrade.

I replaced the calls to `esbuild.build()` with the newer async `esbuild.context()` API, replaced the `watchProps` property with calls to `.watch()` for each esbuild context, and updated the `.serve()` call to use the associated esbuild context.

Since this script was written, [live reload](https://esbuild.github.io/api/#live-reload) has also been better integrated in esbuild, so the live reload config has also been slightly changed to reflect that.

I tried to keep the behaviour of the build script under the various flags as close as possible to the behaviour before making changes, but it would probably be a good idea to test this new script thoroughly in your own development environments. Particularly considering how the change involves switching to working with async promises from esbuild.