### PR TITLE
chore: Add step to install yarn in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ MIZANI_WHEEL=mizani-$(MIZANI_VERSION)-py3-none-any.whl
 VENV = venv
 PYBIN = $(VENV)/bin
 
+# Install Yarn if not already installed
+YARN_INSTALLED := $(shell \
+	yarn -v 2> /dev/null || \
+	(echo >&2 "Yarn is not installed. Installing..."; npm install -g yarn;) \
+)
+
 
 # Any targets that depend on $(VENV) or $(PYBIN) will cause the venv to be
 # created. To use the ven, python scripts should run with the prefix $(PYBIN),

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,6 @@ MIZANI_WHEEL=mizani-$(MIZANI_VERSION)-py3-none-any.whl
 VENV = venv
 PYBIN = $(VENV)/bin
 
-# Install Yarn if not already installed
-YARN_INSTALLED := $(shell \
-	yarn -v 2> /dev/null || \
-	(echo >&2 "Yarn is not installed. Installing..."; npm install -g yarn;) \
-)
-
-
 # Any targets that depend on $(VENV) or $(PYBIN) will cause the venv to be
 # created. To use the ven, python scripts should run with the prefix $(PYBIN),
 # as in `$(PYBIN)/pip`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Code for deploying Shiny applications that will run completely in the browser, u
 
 ## Prerequisites
 
-`Shinylive` leverages `yarn` for dependency management. If you running `yarn --version` on the machine throws `command not found` error,
+`Shinylive` leverages `yarn` for dependency management. If running `yarn --version` on the machine throws `command not found` error,
 install `yarn` on the machine by following the yarn installation documentation [here](https://classic.yarnpkg.com/lang/en/docs/install)
 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Code for deploying Shiny applications that will run completely in the browser, u
 * Current semi-stable version (deployed from `deploy` branch of this repo): https://shinylive.io/py/examples/
 * Latest dev version (deployed from `main` branch of this repo): https://rstudio.github.io/shinylive/examples/
 
+## Prerequisites
+
+`Shinylive` leverages `yarn` for dependency management. If you running `yarn --version` on the machine throws `command not found` error,
+install `yarn` on the machine by following the yarn installation documentation [here](https://classic.yarnpkg.com/lang/en/docs/install)
+
+
 ## Build instructions
 
 You must first initialize the git submodules. This only needs to be done once:


### PR DESCRIPTION
### WHAT?
The first time I ran the command `make all` it threw an error
```sh
yarn
make: yarn: No such file or directory
make: *** [node_modules] Error 1
```
This was because `yarn` wasn't installed on the machine and it was required for installing other packages.

### HOW?
Create a variable in the makefile that checks if `yarn` exists on the machine, if not it will install it.

### POTENTIAL OPTIMIZATION?
It can probably be optimized by only invoking it when `node_modules` target is invoked.

### HOW WAS IT TESTED?
Removed `node_modules` -> `npm uninstall -g yarn` -> Run `make node_modules`. Check log to contain
```sh
➜  shinylive git:(main) make node_modules
Yarn is not installed. Installing...
yarn
```

After `yarn` is already installed, run `make node_modules` -> Check the logs to see if yarn wasn't installed again.
```sh
make node_modules
yarn
```
