### PR TITLE
Apply Greg styling suggestions to orbit; use modules

### DIFF
--- a/examples/orbit/app.py
+++ b/examples/orbit/app.py
@@ -3,170 +3,91 @@ from pathlib import Path
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
+import shiny.experimental as x
+from body import body_server, body_ui
+from faicons import icon_svg
 from shiny import App, reactive, render, ui
-from simulation import Body, Simulation, nbody_solve, spherical_to_cartesian
+from simulation import Simulation, nbody_solve
 
 # This application adapted from RK4 Orbit Integrator tutorial in Python for Astronomers
 # https://prappleizer.github.io/
 
 
-def panel_box(*args, **kwargs):
-    return ui.div(
-        ui.div(*args, class_="card-body"),
-        **kwargs,
-        class_="card mb-3",
-    )
-
-
-app_ui = ui.page_fluid(
-    {"class": "p-4"},
-    ui.row(
-        ui.column(
-            4,
-            panel_box(
-                ui.input_slider("days", "Simulation duration (days)", 0, 200, value=60),
-                ui.input_slider(
-                    "step_size",
-                    "Simulation time step (hours)",
-                    0,
-                    24,
-                    value=4,
-                    step=0.5,
-                ),
-                ui.input_action_button(
-                    "run", "Run simulation", class_="btn-primary w-100"
-                ),
-            ),
-            ui.navset_tab_card(
-                ui.nav(
-                    "Earth",
-                    ui.input_checkbox("earth", "Enable", True),
-                    ui.panel_conditional(
-                        "input.earth",
-                        ui.input_numeric(
-                            "earth_mass",
-                            "Mass (10^22 kg)",
-                            597.216,
-                        ),
-                        ui.input_slider(
-                            "earth_speed",
-                            "Speed (km/s)",
-                            0,
-                            1,
-                            value=0.0126,
-                            step=0.001,
-                        ),
-                        ui.input_slider("earth_theta", "Angle (𝜃)", 0, 360, value=270),
-                        ui.input_slider("earth_phi", "𝜙", 0, 180, value=90),
-                    ),
-                ),
-                ui.nav(
-                    "Moon",
-                    ui.input_checkbox("moon", "Enable", True),
-                    ui.panel_conditional(
-                        "input.moon",
-                        ui.input_numeric("moon_mass", "Mass (10^22 kg)", 7.347),
-                        ui.input_slider(
-                            "moon_speed", "Speed (km/s)", 0, 2, value=1.022, step=0.001
-                        ),
-                        ui.input_slider("moon_theta", "Angle (𝜃)", 0, 360, value=90),
-                        ui.input_slider("moon_phi", "𝜙", 0, 180, value=90),
-                    ),
-                ),
-                ui.nav(
-                    "Planet X",
-                    ui.input_checkbox("planetx", "Enable", False),
-                    ui.output_ui("planetx_controls"),
-                    ui.panel_conditional(
-                        "input.planetx",
-                        ui.input_numeric("planetx_mass", "Mass (10^22 kg)", 7.347),
-                        ui.input_slider(
-                            "planetx_speed",
-                            "Speed (km/s)",
-                            0,
-                            2,
-                            value=1.022,
-                            step=0.001,
-                        ),
-                        ui.input_slider("planetx_theta", "Angle (𝜃)", 0, 360, 270),
-                        ui.input_slider("planetx_phi", "𝜙", 0, 180, 90),
-                    ),
-                ),
-            ),
+app_ui = x.ui.page_sidebar(
+    x.ui.sidebar(
+        ui.input_slider("days", "Simulation duration (days)", 0, 200, value=60),
+        ui.input_slider(
+            "step_size",
+            "Simulation time step (hours)",
+            0,
+            24,
+            value=4,
+            step=0.5,
         ),
-        ui.column(
-            8,
-            ui.output_plot("orbits", width="500px", height="500px"),
-            ui.img(src="coords.png", style="width: 100%; max-width: 250px;"),
+        ui.input_action_button(
+            "run", "Simulate", icon=icon_svg("play"), class_="btn-primary w-100"
+        ),
+        x.ui.accordion(
+            x.ui.accordion_panel(
+                "Earth",
+                body_ui(
+                    "earth", enable=True, mass=597.216, speed=0.0126, theta=270, phi=90
+                ),
+            ),
+            x.ui.accordion_panel(
+                "Moon",
+                body_ui("moon", enable=True, mass=7.347, speed=1.022, theta=90, phi=90),
+            ),
+            x.ui.accordion_panel(
+                "Planet X",
+                body_ui(
+                    "planetx", enable=False, mass=7.347, speed=1.022, theta=270, phi=90
+                ),
+            ),
+            open=False,
+            multiple=False,
+            # mt-4: margin top 4; adds a bit of space above the accordion
+            class_="mt-4",
+            # Give the accordion the same background color as the sidebar
+            style="--bs-accordion-bg: --bslib-sidebar-bg;",
         ),
     ),
+    x.ui.output_plot("orbits"),
+    ui.panel_absolute(
+        ui.img(src="coords.png", style="width: 100%; max-width: 225px;"),
+        bottom="1em",
+        right="1em",
+        class_="border d-none d-md-block",
+    ),
+    fillable=True,
 )
 
 
 def server(input, output, session):
-    def earth_body():
-        v = spherical_to_cartesian(
-            input.earth_theta(), input.earth_phi(), input.earth_speed()
-        )
+    earth_body = body_server("earth", "Earth", [0, 0, 0])
+    moon_body = body_server("moon", "Moon", [3.84e5, 0, 0])
+    planetx_body = body_server("planetx", "Planet X", [-3.84e5, 0, 0])
 
-        return Body(
-            mass=input.earth_mass() * 10e21 * u.kg,
-            x_vec=np.array([0, 0, 0]) * u.km,
-            v_vec=np.array(v) * u.km / u.s,
-            name="Earth",
-        )
-
-    def moon_body():
-        v = spherical_to_cartesian(
-            input.moon_theta(), input.moon_phi(), input.moon_speed()
-        )
-
-        return Body(
-            mass=input.moon_mass() * 10e21 * u.kg,
-            x_vec=np.array([3.84e5, 0, 0]) * u.km,
-            v_vec=np.array(v) * u.km / u.s,
-            name="Moon",
-        )
-
-    def planetx_body():
-        v = spherical_to_cartesian(
-            input.planetx_theta(), input.planetx_phi(), input.planetx_speed()
-        )
-
-        return Body(
-            mass=input.planetx_mass() * 10e21 * u.kg,
-            x_vec=np.array([-3.84e5, 0, 0]) * u.km,
-            v_vec=np.array(v) * u.km / u.s,
-            name="Planet X",
-        )
-
+    @reactive.Calc()
     def simulation():
-        bodies = []
-        if input.earth():
-            bodies.append(earth_body())
-        if input.moon():
-            bodies.append(moon_body())
-        if input.planetx():
-            bodies.append(planetx_body())
+        bodies = [
+            x for x in [earth_body(), moon_body(), planetx_body()] if x is not None
+        ]
 
-        simulation_ = Simulation(bodies)
-        simulation_.set_diff_eq(nbody_solve)
+        sim = Simulation(bodies)
+        sim.set_diff_eq(nbody_solve)
 
-        return simulation_
+        n_steps = input.days() * 24 / input.step_size()
+        with ui.Progress(min=1, max=n_steps) as p:
+            sim.run(input.days() * u.day, input.step_size() * u.hr, progress=p)
+
+        return sim.history
 
     @output
     @render.plot
     @reactive.event(input.run, ignore_none=False)
     def orbits():
-        return make_orbit_plot()
-
-    def make_orbit_plot():
-        sim = simulation()
-        n_steps = input.days() * 24 / input.step_size()
-        with ui.Progress(min=1, max=n_steps) as p:
-            sim.run(input.days() * u.day, input.step_size() * u.hr, progress=p)
-
-        sim_hist = sim.history
+        sim_hist = simulation()
         end_idx = len(sim_hist) - 1
 
         fig = plt.figure()

--- a/examples/orbit/app.py
+++ b/examples/orbit/app.py
@@ -59,7 +59,6 @@ app_ui = x.ui.page_sidebar(
         right="1em",
         class_="border d-none d-md-block",
     ),
-    fillable=True,
 )
 
 

--- a/examples/orbit/body.py
+++ b/examples/orbit/body.py
@@ -1,0 +1,56 @@
+"""Body Shiny module
+
+A Shiny module that represents a body (i.e. planet/moon) in the simulation. This allows
+us to have multiple bodies in the simulation, each sharing similar UI and server logic,
+without having to repeat the code.
+
+Learn more about Shiny modules at: https://shiny.posit.co/py/docs/workflow-modules.html
+"""
+import astropy.units as u
+import numpy as np
+from shiny import module, reactive, ui
+from simulation import Body, spherical_to_cartesian
+
+
+@module.ui
+def body_ui(enable, mass, speed, theta, phi):
+    return ui.TagList(
+        ui.input_checkbox("enable", "Enable", enable),
+        ui.panel_conditional(
+            "input.enable",
+            ui.input_numeric(
+                "mass",
+                "Mass (10^22 kg)",
+                mass,
+            ),
+            ui.input_slider(
+                "speed",
+                "Speed (km/s)",
+                0,
+                1,
+                value=speed,
+                step=0.001,
+            ),
+            ui.input_slider("theta", "Angle (𝜃)", 0, 360, value=theta),
+            ui.input_slider("phi", "𝜙", 0, 180, value=phi),
+        ),
+    )
+
+
+@module.server
+def body_server(input, output, session, label, start_vec):
+    @reactive.Calc
+    def body_result():
+        if not input.enable():
+            return None
+
+        v = spherical_to_cartesian(input.theta(), input.phi(), input.speed())
+
+        return Body(
+            mass=input.mass() * 10e21 * u.kg,
+            x_vec=np.array(start_vec) * u.km,
+            v_vec=np.array(v) * u.km / u.s,
+            name=label,
+        )
+
+    return body_result

--- a/examples/orbit/body.py
+++ b/examples/orbit/body.py
@@ -47,7 +47,7 @@ def body_server(input, output, session, label, start_vec):
         v = spherical_to_cartesian(input.theta(), input.phi(), input.speed())
 
         return Body(
-            mass=input.mass() * 10e21 * u.kg,
+            mass=input.mass() * 1e22 * u.kg,
             x_vec=np.array(start_vec) * u.km,
             v_vec=np.array(v) * u.km / u.s,
             name=label,


### PR DESCRIPTION
UI changes:

1. Use fillable plot output for simulation plot
2. Tuck direction diagram into the bottom-right corner (and hide it on smaller screen sizes)
3. Use sidebar layout
4. Put earth, moon, planetx into accordion

Code change:

1. Use Shiny modules for earth/moon/planetx
2. Separate simulation logic from plotting logic

## Before

![shinylive io_py_app_ (3)](https://github.com/rstudio/shinylive/assets/129551/e65f960b-9635-4206-b567-0d7397c2c565)

## After

![localhost_60332_](https://github.com/rstudio/shinylive/assets/129551/851e064c-f8ab-4ac2-b9f9-c94088ba4978)
![localhost_60332_ (1)](https://github.com/rstudio/shinylive/assets/129551/72790a7f-d5ad-413c-a4fc-7e8a54d94b68)
